### PR TITLE
Show solution percentages in practice and add Next hotkey

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
             </div>
             <p id="feedback-text"></p>
             <div id="score-display">Helyes: 0 / 0</div>
-            <button id="next-question-btn" class="hidden">Következő Kérdés</button>
+            <button id="next-question-btn" class="hidden">Következő Kérdés (N)</button>
             <button id="exit-practice-btn" class="secondary-btn">Kilépés a gyakorlásból</button>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -142,12 +142,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         score.total++;
+        const solutionText = feedbackString.slice(0, -2);
         if (correctActions.includes(userAnswer)) {
             score.correct++;
-            feedbackText.textContent = 'Helyes!';
+            feedbackText.textContent = 'Helyes! ' + solutionText;
             feedbackText.className = 'feedback-correct';
         } else {
-            feedbackText.textContent = 'Helytelen. ' + feedbackString.slice(0, -2);
+            feedbackText.textContent = 'Helytelen. ' + solutionText;
             feedbackText.className = 'feedback-incorrect';
         }
         
@@ -180,6 +181,13 @@ document.addEventListener('DOMContentLoaded', () => {
     practiceBtn.addEventListener('click', startPractice);
     exitPracticeBtn.addEventListener('click', exitPractice);
     nextQuestionBtn.addEventListener('click', generateNewQuestion);
+    document.addEventListener('keydown', (event) => {
+        if (!practiceModeDiv.classList.contains('hidden') &&
+            !nextQuestionBtn.classList.contains('hidden') &&
+            event.key.toLowerCase() === 'n') {
+            generateNewQuestion();
+        }
+    });
     answerButtonsContainer.addEventListener('click', (event) => {
         if (event.target.classList.contains('answer-btn')) {
             checkAnswer(event.target.dataset.action);


### PR DESCRIPTION
## Summary
- Always display detailed correct actions with percentages after answering in practice mode
- Added keyboard shortcut 'N' to jump to the next practice question and updated button label

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a58a280df08333ba35c9f14b47b431