### PR TITLE
Translate interface to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="hu">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>14bb GTO Stratégia Elemző</title>
+    <title>14bb GTO Strategy Analyzer</title>
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -12,53 +12,53 @@
 <body>
     <div class="container">
         <div id="main-content">
-            <h1>14bb GTO Stratégia Elemző</h1>
-            <p class="subtitle">Írd be a kezeket a mezőkbe, majd generáld az ábrát a tanuláshoz.</p>
+            <h1>14bb GTO Strategy Analyzer</h1>
+            <p class="subtitle">Enter the hands into the fields, then generate the chart to study.</p>
 
             <div class="input-grid">
-                <!-- 12 beviteli mező -->
-                <input type="text" class="hand-input-field" placeholder="Kéz 1">
-                <input type="text" class="hand-input-field" placeholder="Kéz 2">
-                <input type="text" class="hand-input-field" placeholder="Kéz 3">
-                <input type="text" class="hand-input-field" placeholder="Kéz 4">
-                <input type="text" class="hand-input-field" placeholder="Kéz 5">
-                <input type="text" class="hand-input-field" placeholder="Kéz 6">
-                <input type="text" class="hand-input-field" placeholder="Kéz 7">
-                <input type="text" class="hand-input-field" placeholder="Kéz 8">
-                <input type="text" class="hand-input-field" placeholder="Kéz 9">
-                <input type="text" class="hand-input-field" placeholder="Kéz 10">
-                <input type="text" class="hand-input-field" placeholder="Kéz 11">
-                <input type="text" class="hand-input-field" placeholder="Kéz 12">
+                <!-- 12 input fields -->
+                <input type="text" class="hand-input-field" placeholder="Hand 1">
+                <input type="text" class="hand-input-field" placeholder="Hand 2">
+                <input type="text" class="hand-input-field" placeholder="Hand 3">
+                <input type="text" class="hand-input-field" placeholder="Hand 4">
+                <input type="text" class="hand-input-field" placeholder="Hand 5">
+                <input type="text" class="hand-input-field" placeholder="Hand 6">
+                <input type="text" class="hand-input-field" placeholder="Hand 7">
+                <input type="text" class="hand-input-field" placeholder="Hand 8">
+                <input type="text" class="hand-input-field" placeholder="Hand 9">
+                <input type="text" class="hand-input-field" placeholder="Hand 10">
+                <input type="text" class="hand-input-field" placeholder="Hand 11">
+                <input type="text" class="hand-input-field" placeholder="Hand 12">
             </div>
             
             <div class="action-section">
-                <button id="generate-btn">Ábra generálása</button>
-                <button id="practice-btn" class="secondary-btn" disabled>Gyakorlás</button>
+                <button id="generate-btn">Generate Chart</button>
+                <button id="practice-btn" class="secondary-btn" disabled>Practice</button>
             </div>
 
             <div id="chart-container"></div>
         </div>
 
-        <!-- A Gyakorló Mód felülete (alapból rejtett) -->
+        <!-- Practice Mode interface (hidden by default) -->
         <div id="practice-mode" class="hidden">
-            <h2>Gyakorló Mód</h2>
-            <p id="question-text">Mi a helyes lépés...?</p>
+            <h2>Practice Mode</h2>
+            <p id="question-text">What is the correct action...?</p>
             <div id="answer-buttons">
                 <button class="answer-btn" data-action="All-in">All-in</button>
-                <button class="answer-btn" data-action="Raise">Emelés (2bb)</button>
-                <button class="answer-btn" data-action="Fold">Dobás</button>
+                <button class="answer-btn" data-action="Raise">Raise (2bb)</button>
+                <button class="answer-btn" data-action="Fold">Fold</button>
             </div>
             <p id="feedback-text"></p>
-            <div id="score-display">Helyes: 0 / 0</div>
-            <button id="next-question-btn" class="hidden">Következő Kérdés (N)</button>
-            <button id="exit-practice-btn" class="secondary-btn">Kilépés a gyakorlásból</button>
+            <div id="score-display">Correct: 0 / 0</div>
+            <button id="next-question-btn" class="hidden">Next Question (N)</button>
+            <button id="exit-practice-btn" class="secondary-btn">Exit Practice</button>
         </div>
 
 
         <div class="legend">
             <div class="legend-item"><span class="color-box all-in"></span>All-in</div>
-            <div class="legend-item"><span class="color-box raise"></span>Emelés (2bb)</div>
-            <div class="legend-item"><span class="color-box fold"></span>Dobás</div>
+            <div class="legend-item"><span class="color-box raise"></span>Raise (2bb)</div>
+            <div class="legend-item"><span class="color-box fold"></span>Fold</div>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -22,25 +22,25 @@ document.addEventListener('DOMContentLoaded', () => {
     const colors = { 'All-in': '#8b0000', 'Raise': '#f08080', 'Fold': '#add8e6' };
     const actionOrder = ['All-in', 'Raise', 'Fold'];
 
-    // Gombok letiltása, amíg az adatbázis be nem töltődik
+    // Disable buttons until the database loads
     generateBtn.disabled = true;
-    generateBtn.textContent = 'Adatbázis betöltése...';
+    generateBtn.textContent = 'Loading database...';
     practiceBtn.disabled = true;
 
     fetch('strategy_database.json')
         .then(response => response.ok ? response.json() : Promise.reject('Network response was not ok'))
         .then(data => {
             masterStrategyData = data;
-            // JAVÍTÁS: Mindkét gomb engedélyezése a sikeres betöltés után
+            // FIX: Enable both buttons after successful load
             generateBtn.disabled = false;
-            generateBtn.textContent = 'Ábra generálása';
+            generateBtn.textContent = 'Generate Chart';
             practiceBtn.disabled = false;
         })
         .catch(error => {
             console.error('Error loading database:', error);
-            chartContainer.innerHTML = `<p style="color: #f04747; text-align: center;">HIBA: Az adatbázis ('strategy_database.json') nem tölthető be.</p>`;
-            generateBtn.textContent = 'Hiba az adatbázisban';
-            practiceBtn.textContent = 'Hiba';
+            chartContainer.innerHTML = `<p style="color: #f04747; text-align: center;">ERROR: The database ('strategy_database.json') cannot be loaded.</p>`;
+            generateBtn.textContent = 'Database error';
+            practiceBtn.textContent = 'Error';
         });
 
     function normalizeHandInput(handStr) {
@@ -112,14 +112,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function generateNewQuestion() {
-        // JAVÍTÁS: A kérdések forrásának meghatározása
+        // FIX: Determine the source of questions
         const handsToPracticeFrom = currentHandsInChart.length > 0 ? currentHandsInChart : Object.keys(masterStrategyData);
         
         const randomHand = handsToPracticeFrom[Math.floor(Math.random() * handsToPracticeFrom.length)];
         const randomPosition = positions[Math.floor(Math.random() * positions.length)];
         currentQuestion = { hand: randomHand, position: randomPosition };
 
-        questionText.innerHTML = `Mi a helyes lépés a(z) <strong>${randomHand}</strong> kézzel <strong>${randomPosition}</strong> pozícióból?`;
+        questionText.innerHTML = `What is the correct action with <strong>${randomHand}</strong> from <strong>${randomPosition}</strong> position?`;
         
         feedbackText.textContent = '';
         feedbackText.className = '';
@@ -132,9 +132,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const freqs = masterStrategyData[hand]?.[position] || [0.0, 0.0, 1.0];
         
         const correctActions = [];
-        let feedbackString = 'A helyes lépés(ek): ';
+        let feedbackString = 'The correct action(s): ';
         freqs.forEach((freq, index) => {
-            if (freq > 0.001) { // Kis kerekítési hibák kiszűrése
+            if (freq > 0.001) { // Filter out small rounding errors
                 const action = actionOrder[index];
                 correctActions.push(action);
                 feedbackString += `${action} (${Math.round(freq*100)}%), `;
@@ -145,10 +145,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const solutionText = feedbackString.slice(0, -2);
         if (correctActions.includes(userAnswer)) {
             score.correct++;
-            feedbackText.textContent = 'Helyes! ' + solutionText;
+            feedbackText.textContent = 'Correct! ' + solutionText;
             feedbackText.className = 'feedback-correct';
         } else {
-            feedbackText.textContent = 'Helytelen. ' + solutionText;
+            feedbackText.textContent = 'Incorrect. ' + solutionText;
             feedbackText.className = 'feedback-incorrect';
         }
         
@@ -158,7 +158,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateScoreDisplay() {
-        scoreDisplay.textContent = `Helyes: ${score.correct} / ${score.total}`;
+        scoreDisplay.textContent = `Correct: ${score.correct} / ${score.total}`;
     }
 
     generateBtn.addEventListener('click', () => {
@@ -170,11 +170,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (masterStrategyData[normalizedHand]) {
                     handsToChart.add(normalizedHand);
                 } else {
-                    console.warn(`'${rawHand}' -> '${normalizedHand}' nem található.`);
+                    console.warn(`'${rawHand}' -> '${normalizedHand}' not found.`);
                 }
             }
         });
-        // Az üres generálás is törli a táblát, de a gyakorlás gomb aktív marad
+        // Generating with no input also clears the table, but the practice button stays active
         generateChart(Array.from(handsToChart));
     });
 

--- a/style.css
+++ b/style.css
@@ -121,13 +121,13 @@ button {
 .raise { background-color: #f08080; }
 .fold { background-color: #add8e6; }
 
-/* Gyakorló mód stílusok */
+/* Practice mode styles */
 #practice-mode { padding: 20px; border: 2px solid #4f545c; border-radius: 8px; text-align: center; }
 #question-text { font-size: 1.2em; margin-bottom: 20px; }
 #question-text strong { color: #7289da; }
 #answer-buttons { display: flex; justify-content: center; gap: 15px; margin-bottom: 20px; }
 
-/* JAVÍTÁS: A válasz gombok háttérszíne */
+/* FIX: Answer button background color */
 .answer-btn {
     font-size: 1em;
     width: 140px;


### PR DESCRIPTION
## Summary
- Translate HTML content to English, including headings, placeholders, and practice mode controls
- Localize client-side logic to English with new status messages and feedback strings
- Update comments and styles to use English wording

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a618a87dc083338b5f5b741ce9c626